### PR TITLE
Exception in the load process of the object structure resolved.

### DIFF
--- a/ng-providers/loadingManagerProvider.js
+++ b/ng-providers/loadingManagerProvider.js
@@ -242,7 +242,7 @@ angular.module('atlasDemo').provider('loadingManager', ['mainAppProvider', 'volu
 
         var objStructures = atlasStructure.Structure.filter(item => {
             if (Array.isArray(item.sourceSelector)) {
-                return item.sourceSelector.some(selector => /\.obj$/.test(selector.dataSource.source));
+                return item.sourceSelector.some(selector => /\.obj$/.test(selector.dataSource && selector.dataSource.source));
             }
             else {
                 return /\.obj$/.test(item.sourceSelector.dataSource.source);


### PR DESCRIPTION
I had various problems with multiple atlas because of dataSource object does not exist and the regular expression throws exception. This modification has resolved my problem.